### PR TITLE
add release notes v0.1.6 including review comments and fix  bug in doc building

### DIFF
--- a/docs/whatsnew/v0.1.6.rst
+++ b/docs/whatsnew/v0.1.6.rst
@@ -38,11 +38,24 @@ Bug fixes
 
   .. code-block:: default 
 
-      File "/home/docs/checkouts/readthedocs.org/user_builds/watex/envs/master/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 224, in __getattr__
-          raise AttributeError(
-      AttributeError: module 'matplotlib.cm' has no attribute 'cmap_d'
+      Unexpected failing examples:
+      
+      /home/docs/checkouts/readthedocs.org/user_builds/watex/checkouts/master/examples/methods/plot_phase_tensors.py failed leaving traceback:
+      Traceback (most recent call last):
+        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/checkouts/master/examples/methods/plot_phase_tensors.py", line 39, in <module>
+           tplot.plot_phase_tensors (ellipse_dict= ellip_dic)
+        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/checkouts/master/watex/view/plot.py", line 826, in plot_phase_tensors
+           from mtpy.imaging.phase_tensor_pseudosection import (
+        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/envs/master/lib/python3.10/site-packages/mtpy/imaging/phase_tensor_pseudosection.py", line 18, in <module>
+           import mtpy.imaging.mtcolors as mtcl
+        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/envs/master/lib/python3.10/site-packages/mtpy/imaging/mtcolors.py", line 252, in <module>
+           cmapdict.update(cm.cmap_d)
+        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/envs/master/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 224, in __getattr__
+           raise AttributeError(
+        AttributeError: module 'matplotlib.cm' has no attribute 'cmap_d'
 
-  We fix it ( just for doc building ) by using the matplotlib colormaps rather than MTpy proper colors. 
+  To fix it and let the doc building correctly, we uncomment the example in gallery ``methods.plot_phase_tensors.py`` ( just for doc building ) 
+  rather than using the matplotlib colormaps instead since  MTpy proper colors don't work. 
   
   
 .. _comments: 

--- a/examples/methods/plot_phase_tensors.py
+++ b/examples/methods/plot_phase_tensors.py
@@ -27,6 +27,10 @@ edi_samples = wx.fetch_data ('huayuan', samples =27 , return_data = True )
 # *  Ellipse of ``'phimin'``  
 tplot= wx.TPlot (fig_size =( 5, 2 )).fit(edi_samples )
 # --------------------------------------------------
+# THIS SECTION IS JUST COMMENTED FOR DOC BUILDING 
+# SEE RELEASE NOTES v0.1.6 FOR THE REASON 
+# UNCOMMENT ">>>.." LINES AND RUN IT FOR TENSOR VISUALIZATION 
+# 
 # we can skip the ellip_dic config by using the defaut customization. However 
 # to skip the error from MTpy color when building the doc, we use the matplotlib
 # conventional colormap instead. 
@@ -36,7 +40,7 @@ ellip_dic = {'ellipse_colorby':'phimin',
             'ellip_size': 2, 
             'ellipse_cmap':'bwr' # or color defined in `cmap` parameter such as `mt_bl2wh2rd`
             }
-tplot.plot_phase_tensors (ellipse_dict= ellip_dic)
+# >>> tplot.plot_phase_tensors (ellipse_dict= ellip_dic)
 # by default the color limit for 'phmin' is [0, 90] 
 # %%
 # * Ellipse of ``'skew'`` visualization 
@@ -47,11 +51,11 @@ ellip_dic_sk = {'ellipse_colorby':'skew',
             'ellip_size': 2, 
             'ellipse_cmap':'PuOr' # or color defined in `cmap` parameter such as `mt_bl2wh2rd`
             }
-#>>> tplot.plot_phase_tensor (ellipse_dict=ellip_dic )
+# >>> tplot.plot_phase_tensor (ellipse_dict=ellip_dic )
 # or simply turn on `tensor` parameter to ``skew`` like: 
-tplot.plot_phase_tensors (tensor='skew' , ellipse_dict=ellip_dic_sk)
+# >>> tplot.plot_phase_tensors (tensor='skew' , ellipse_dict=ellip_dic_sk)
 
 # %% 
 # * Determinant of phase tensor ``'phidet'``
-tplot.plot_phase_tensors (tensor='phidet', ellipse_dict= ellip_dic_sk )
+# >>> tplot.plot_phase_tensors (tensor='phidet', ellipse_dict= ellip_dic_sk )
 


### PR DESCRIPTION
- Add :func:`watex.utils.get2dtensor` for getting the tensor from 3D to 2D after signal 
  recovery with :meth:`watex.methods.Processing.zrestore`. 

- Add skew visualization: :func:`watex.utils.plot_skew` for phase-sensitive visualization; :meth:`watex.view.TPlot.plotSkew` 
  for a consistent plot for phase-sensitive visualization

- Visualizes the phase tensors with  :meth:`watex.view.TPlot.plot_phase_tensors`. 

- Load Huayuan :term:`SEG`- :term:`EDI` datasets from :func:`watex.datasets.load_huayuan`. 

- Warn user when DC-parameters can be computed because of constraints (fixed ``AttributeError``
  in :meth:`watex.methods.ResistivityProfiling.summary`)

- add ``openpyxl`` as the hard dependency at the initiliation of the package to avoid crashing 
  when :mod:`watex.geology` module is called. 

- Bug fixed when calling the fine-tuned models from :class:`watex.GridSearchMultiple` objet. Henceforth models 
  can be fetched as :class:`watex.utils.box.Boxspace` object that saves the estimator parameters, model names and 
  cv results. 
  
- when building the :code:`watex` documenation, :meth:`watex.view.TPlot.plot_phase_tensors` calls MTpy imaging 
  module which call matplotlib in turn to update MTpy propers colors. However, it does not recognize ``cmap_d`` in 
  the ``cmapdict.update(cm.cmap_d)`` of code line 252 by showing and ``AttributeError`` like below:: 

        File "/home/docs/checkouts/readthedocs.org/user_builds/watex/envs/master/lib/python3.10/site- 
               packages/matplotlib/_api/__init__.py", line 224, in __getattr__
           raise AttributeError(
        AttributeError: module 'matplotlib.cm' has no attribute 'cmap_d'

  To fix it and let the doc building correctly, we uncomment the example in gallery ``methods.plot_phase_tensors.py`` ( just for doc building ) 
  rather than using the matplotlib colormaps instead since  MTpy proper colors don't work. 