### PR TITLE
Bug fix with ~TPlot.plot_phase_tensors using Matplotlib version v3.5.3 max

### DIFF
--- a/docs/whatsnew/v0.1.6.rst
+++ b/docs/whatsnew/v0.1.6.rst
@@ -50,11 +50,12 @@ Bug fixes
            raise AttributeError(
         AttributeError: module 'matplotlib.cm' has no attribute 'cmap_d'
 
-  To fix it and let the doc building correctly, we uncomment the example in gallery ``methods.plot_phase_tensors.py`` ( just for doc building ) 
-  rather than using the matplotlib colormaps instead since  MTpy proper colors don't work. 
+  To fix it and let the doc building correctly with the latest version of matplotlib, uncomment the examples in gallery 
+  ``methods.plot_phase_tensors.py`` :meth:`watex.view.TPlot.plot_phase_tensors` object `tplot` rather than using the 
+  matplotlib colormaps instead since  MTpy proper colors don't work. An error will raise in both case...
 
-- Plot phase tensor uses Matplotlib version 3.5.3 max. The latest version will yield an attribute error probably
-  due to the use of `cmap_d` in updating MTpy proper colors ``cmapdict.update(cm.cmap_d)``. 
+- Bug fix with :meth:`watex.view.TPlot.plot_phase_tensors` using Matplotlib version 3.5.3 max. The latest version will yield an 
+  attribute error due to the use of `cmap_d` in updating MTpy proper colors ``cmapdict.update(cm.cmap_d)``. 
   
 - Bug fixes in loading the :func:`watex.models.displayCVTables` from :class:`watex.models.GridSearchMultiple`.  Use try -except instead to accept the 
   fine-tuned models directly from :class:`watex.exlib.GridSearchCV` or  :class:`watex.models.GridSearchMultiple` or :class:`watex.models.GridSearch`  

--- a/examples/methods/plot_phase_tensors.py
+++ b/examples/methods/plot_phase_tensors.py
@@ -27,8 +27,9 @@ edi_samples = wx.fetch_data ('huayuan', samples =27 , return_data = True )
 # *  Ellipse of ``'phimin'``  
 tplot= wx.TPlot (fig_size =( 5, 2 )).fit(edi_samples )
 # --------------------------------------------------
-# TO BUILD THE DOC WITH, WE USE MATPLOTLIB >3.5.2, COMMENT 
-# LINES STARTING WITH  "tplot. "  RUN IT 
+# TO BUILD THE DOC WITH  MATPLOTLIB >3.5.3, COMMENT 
+# THE LINES STARTING WITH  "tplot. " TO SKIP ERROR GENERATED 
+# FROM MTPY WHEN UPDATING INNER COLORS
 # SEE RELEASE NOTES v0.1.6 FOR THE REASON 
 # 
 # We can skip the ellip_dic config by using the defaut customization. However 

--- a/examples/utils/plot_skew.py
+++ b/examples/utils/plot_skew.py
@@ -3,7 +3,7 @@
 Plot phase sensitive skew 
 ===================================
 
-shows the phase sensitivity Skew (:math:`\mu`) that 
+shows the phase sensitivity Skew that 
 represents a measure of the skew of the  
 phases of the impedance tensor
 """

--- a/examples/view/plot_phase_sensistive_skew.py
+++ b/examples/view/plot_phase_sensistive_skew.py
@@ -3,7 +3,7 @@
 Plot Skew
 =================================================
 
-Phase sensistive skew visualization from :class:`watex.view.TPlot`.
+Phase sensitive skew visualization
 
 """
 # Author: L.Kouadio 
@@ -34,15 +34,15 @@ Phase sensistive skew visualization from :class:`watex.view.TPlot`.
 #   Phase-sensitive skews less than 0.1 indicate 1D, 2D or distorted 
 #   2D (3-D /2-D) cases. Values of :math:`mu` between 0.1 and 0.3 indicates 
 #   modified 3D/2D structures. 
-  
 # Here is an example of implementation using the :class:`watex.view.TPlot` class 
 # of module :mod:`watex.view`. 
-# we start by importing ``watex`` as 
+# we start by importing ``watex`` as: 
 import watex 
 
 # * `Swift method` 
 test_data = watex.fetch_data ('edis', samples =37, return_data =True )
 tplot = watex.TPlot(fig_size =(10,  4), marker ='x').fit(test_data)
+tplot.plt_style='classic'
 tplot.plotSkew(method ='swift', threshold_line=True)
 
 # %%


### PR DESCRIPTION
- Bug fix with :meth:`watex.view.TPlot.plot_phase_tensors` using Matplotlib version 3.5.3 max. The latest version will yield an 
  attribute error due to the use of `cmap_d` in updating MTpy proper colors ``cmapdict.update(cm.cmap_d)``. 
  
- Bug fixes in loading the :func:`watex.models.displayCVTables` from :class:`watex.models.GridSearchMultiple`.  Use try -except instead to accept the fine-tuned models directly from :class:`watex.exlib.GridSearchCV` or  :class:`watex.models.GridSearchMultiple` or :class:`watex.models.GridSearch`  
  