### PR TITLE
fix installation Cython dependency from flask8 when matplotlib is set to >3.5.3 

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,7 +1,7 @@
 # --find-links https://pypi.anaconda.org/scipy-wheels-nightly/simple/watex
 # --pre
 scikit-learn
-matplotlib==3.5.2
+matplotlib
 pandas
 seaborn
 sphinx-gallery

--- a/docs/whatsnew/v0.1.6-alpha.rst
+++ b/docs/whatsnew/v0.1.6-alpha.rst
@@ -5,7 +5,7 @@ v0.1.6-alpha (February 22, 2023)
 
 These are minor changes performed from ``v0.1.5`` after the review :ref:`comments <comments>` from Editors and Reviewers 
 from the `softwareX <https://www.sciencedirect.com/journal/softwarex>`__ journal to improve the paper and software. 
-Here is the comments/replies section of reviewers  for  **minor revisions** that includes some bug fixes and improvements.
+Here is the comments/replies section of reviewers  for  **minor revisions** that includes some bug fixes and improvements. 
 The reviewers comments are in *italic* whereas the replies are in normal text. 
    
 .. _reviewer1: 

--- a/docs/whatsnew/v0.1.6.rst
+++ b/docs/whatsnew/v0.1.6.rst
@@ -1,9 +1,8 @@
 v0.1.6 (February 26, 2023)
 ----------------------------
 
-This is a minor change performed from ``v0.1.6-alpha`` and bug fixes for issues identified. Furthermore, the 
-:ref:`comments <comments>` from Editors and reviewers  to improve the paper submitted to `softwareX <https://www.sciencedirect.com/journal/softwarex>`__ are 
-also displayed in the final section of this note with the replies for  bug fixes and improvements. 
+This is a minor change performed from ``v0.1.6-alpha`` and adaptations, bug fixes and improvements for issues identified.  
+
 
 Adaptations and Features 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Remove force installation with Matplotlib ==3.5.2to successfully run Cython dependency from flask8 