### PR TITLE
fix suppress_outliers in plot_skew

### DIFF
--- a/examples/utils/plot_skew.py
+++ b/examples/utils/plot_skew.py
@@ -67,10 +67,11 @@ import watex as wx
 # * Barh method 
 edi_sk = wx.fetch_data ("edis", return_data =True , samples = 20 ) 
 # we can set the Barh threshold line by setting the threshold line to 'Barh' 
-wx.utils.plot_skew (edi_sk, method ='bahr', threshold_line='bahr', fig_size = (10, 4), style ='classic')  
+wx.utils.plot_skew (edi_sk, method ='bahr', threshold_line='bahr', fig_size = (11, 5), style ='classic')  
 
 #%% 
 # * Swift method 
-wx.utils.plot_skew (edi_sk, method ='swift', threshold_line='swift', fig_size = (10, 4))  
+wx.utils.plot_skew (edi_sk, method ='swift', threshold_line='swift', fig_size = (11, 5), 
+                    mode='periods')  
 
 

--- a/watex/utils/plotutils.py
+++ b/watex/utils/plotutils.py
@@ -2802,7 +2802,9 @@ def plot_skew (
     import watex as wx 
     po =  wx.EMProcessing().fit(edi_obj)
     
-    skew, mu =po.skew(method = method )
+    # remove the outliers in the data
+    # and filled with NaN 
+    skew, mu =po.skew(method = method, suppress_outliers = True  )
     freqs =  1/ po.freqs_ if mode =='period' else po.freqs_ 
     ymat = skew if view =='skew' else mu 
     
@@ -2817,10 +2819,6 @@ def plot_skew (
             threshold_line = 'both'
             
     ct = thr_code.get(str(threshold_line).lower(), None ) 
-    
-    # remove the outliers in the data
-    # and filled with NaN 
-    ymat = remove_outliers(ymat, fill_value= np.nan ) 
     
     for i in range (skew.shape[1]): 
         ax.scatter ( freqs, reshape (ymat[:, i]),**kws )

--- a/watex/view/plot.py
+++ b/watex/view/plot.py
@@ -977,12 +977,11 @@ class TPlot (BasePlot):
         if 'period' in str(mode).lower(): 
             mode ='period'
 
-        skew, mu =self.p_.skew(method = method )
+        skew, mu =self.p_.skew(
+            method = method, suppress_outliers = suppress_outliers
+            )
         freqs =  1/ self.p_.freqs_ if mode =='period' else self.p_.freqs_ 
         ymat = skew if view =='skew' else mu 
-        
-        if suppress_outliers: 
-            ymat = remove_outliers(ymat, fill_value = np.NaN )
         
         fig, ax = plt.subplots(figsize = self.fig_size )
 


### PR DESCRIPTION
- block ``suppress_outliers``  in :func:`watex.utils.plot_skew` to ``True`` and remove matrix computation that 
  implements :func:`~watex.utils.remove_outliers` twice.  
- give an option for ``suppress_outliers``  in :meth:`~watex.view.TPlot.plotSkew` 