### PR TITLE
update ipykernel for building the doc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -38,5 +38,7 @@ mlxtend
 yellowbrick
 plotly
 ipywidgets
+ipykernel
 pandas-profiling
+
 


### PR DESCRIPTION
- ``ipykernel`` seems to be removed from ``ydata_profiling``. Need to install it manually when building the documentation