### PR TITLE
skip reading EDI when passed as a list

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -14,7 +14,7 @@ html[data-theme=light]{
 }
 /*  Style all links with `stable` in the version name*/
 .version-switcher__container a[data-version-name*="stable"] {
-   background-color: green;
+   background-color: #f1ad29;
 }
 /* If the active version has the name "dev", style it*/
 .version-switcher__button[data-active-version-name*="dev"] {

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,9 +4,14 @@
     "version": "latest",
     "url": "https://watex.readthedocs.io/en/latest/"
   },
-    {
-    "name": "0.1.9 (stable)",
+  {
+    "name": "0.2.0 (stable)",
     "version": "stable",
+    "url": "https://watex.readthedocs.io/en/0.2.0/"
+  },
+  {
+    "name": "0.1.9",
+    "version": "v0.1.9",
     "url": "https://watex.readthedocs.io/en/0.1.9/"
   },
   {

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -16,6 +16,7 @@
             Archive
         </a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+		  <a class="dropdown-item" href="https://watex.readthedocs.io/en/0.1.9/">v0.1.9</a>
           <a class="dropdown-item" href="https://watex.readthedocs.io/en/0.1.8/">v0.1.8</a>
           <a class="dropdown-item" href="https://watex.readthedocs.io/en/0.1.7/">v0.1.7</a>
         </div>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -40,5 +40,6 @@ plotly
 ipywidgets
 ipykernel
 pandas-profiling==3.6.1
+pytest
 
 

--- a/watex/utils/plotutils.py
+++ b/watex/utils/plotutils.py
@@ -3085,12 +3085,12 @@ def plot_strike (
     from mtpy.imaging.plotstrike import PlotStrike
     from ..property import IsEdi
     #xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    
-    if os.path.isdir ( list_of_edis ): 
-        list_of_edis = [os.path.join( f) for f in os.listdir (list_of_edis)
-                        if str(f).lower().endswith ('.edi')]
-    if os.path.isfile (list_of_edis): 
-        list_of_edis =[list_of_edis ]
+    if isinstance ( list_of_edis, str): 
+        if os.path.isdir ( list_of_edis ): 
+            list_of_edis = [os.path.join( f) for f in os.listdir (list_of_edis)
+                            if str(f).lower().endswith ('.edi')]
+        if os.path.isfile (list_of_edis): 
+            list_of_edis =[list_of_edis ]
         
     # now check whether is valid EDI     
     # list comprehension faster than


### PR DESCRIPTION
-fix error in  :func:`watex.utils.plot_strike` when a collection of EDI is passed : 
```
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list
``` 