### PR TITLE
oading local assets which include url query strings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_theme =  "pydata_sphinx_theme"
 
 
 html_static_path = ['_static', 'example_thumbs']
-html_css_files =  [f'css/custom.css?v={watex.__version__}']
+html_css_files =  [f"css/custom.css?v={watex.__version__}"]
 
 # todo_include_todos = True
 html_logo = "_static/logo.svg"

--- a/watex/__init__.py
+++ b/watex/__init__.py
@@ -35,7 +35,7 @@ try:
     from . import _version
     __version__ = _version.version.split('.dev')[0]
 except ImportError:
-    __version__ = '0.3.0' 
+    __version__ = "0.3.0"
 
 # # set loging Level
 logging.getLogger(__name__)#.setLevel(logging.WARNING)


### PR DESCRIPTION
building documentation , 
error code 

.. code-block: : default 
`Theme error:
`An error happened in rendering the page analysis.
`Reason: ThemeError("Local asset file paths must not contain query strings: '_static/css/custom.css?v=0.3.0'")