### PR TITLE
fix issues in sklearn_proxy change

### DIFF
--- a/examples/applications/plot_kmf.py
+++ b/examples/applications/plot_kmf.py
@@ -31,7 +31,8 @@ from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
 
 from watex.datasets import load_mxs
-from watex.exlib import train_test_split, XGBClassifier, roc_auc_score,roc_curve 
+from watex.exlib import train_test_split, roc_auc_score,roc_curve 
+from watex.exlib.gbm import XGBClassifier
 from watex.transformers import featurize_X,  KMeansFeaturizer
 from watex.utils import plot_voronoi, plot_roc_curves, replace_data
 

--- a/examples/view/plot_phase_sensistive_skew.py
+++ b/examples/view/plot_phase_sensistive_skew.py
@@ -39,12 +39,16 @@ two dimensional.
 # of module :mod:`watex.view`. 
 # we start by importing ``watex`` as: 
 import numpy as np
-import watex 
+
+import watex  as wx 
+from watex.methods import EMAP 
+from watex.view import TPlot, plot2d
+
 
 # %%
 # * `Swift method` 
-test_data = watex.fetch_data ('edis', samples =37, return_data =True )
-tplot = watex.TPlot(fig_size =(11,  5), marker ='x').fit(test_data)
+test_data = wx.fetch_data ('edis', samples =37, return_data =True )
+tplot = TPlot(fig_size =(11,  5), marker ='x').fit(test_data)
 tplot.plt_style='classic'
 tplot.plotSkew(method ='swift', threshold_line=True)
 
@@ -68,19 +72,19 @@ tplot.plotSkew(threshold_line=True, suppress_outliers=False )
 # In addition, setting the `return_skewness` parameter to ``skew``
 # returns only the skew value. The default behavior returns both the skew and 
 # the rotation all of invariant :math:`\eta`. 
-skv = watex.EMAP ().fit(test_data).skew(return_skewness='skew') # to return only skew value,
-watex.view.plot2d (skv, y = np.log10 (tplot.p_.freqs_ ),
-                   distance =50., # distance between stations
-                   top_label='Stations',
-                   show_grid =True, 
-                   fig_size = ( 11, 5 ), 
-                   cmap = 'bwr', 
-                   font_size =7, 
-                   ylabel ='Log10Frequency[$H_z$]', 
-                   xlabel='Distance (m)', 
-                   cb_label ='Skew: swift', 
-                  
-                   )
+skv = EMAP ().fit(test_data).skew(return_skewness='skew') # to return only skew value,
+plot2d (skv, y = np.log10 (tplot.p_.freqs_ ),
+        distance =50., # distance between stations
+        top_label='Stations',
+        show_grid =True, 
+        fig_size = ( 11, 5 ), 
+        cmap = 'bwr', 
+        font_size =7, 
+        ylabel ='Log10Frequency[$H_z$]', 
+        xlabel='Distance (m)', 
+        cb_label ='Skew: swift', 
+       
+        )
 # %%
 # As shown in Figure above, the value of skew is smaller than 0.4 at most sites, 
 # indicating a 2D structure. Only a few sites near the fault have a 
@@ -88,18 +92,18 @@ watex.view.plot2d (skv, y = np.log10 (tplot.p_.freqs_ ),
 # the electricity model of the research area can be approximated to a 2D 
 # structure for inversion.  
 # In the next example, we will suppress the outliers in the data.  
-skv = watex.EMAP ().fit(test_data).skew(
+skv = EMAP ().fit(test_data).skew(
     return_skewness='skew', suppress_outliers = True) 
-watex.view.plot2d (skv, y = np.log10 (tplot.p_.freqs_ ),
-                   distance =50., 
-                   show_grid =True, 
-                   fig_size = ( 11, 5 ), 
-                   cmap = 'bwr', 
-                   font_size =7, 
-                   ylabel ='Log10Frequency[$H_z$]', 
-                   xlabel='Distance (m)', 
-                   cb_label ='Skew: Swift', 
-                   )
+plot2d (skv, y = np.log10 (tplot.p_.freqs_ ),
+        distance =50., 
+        show_grid =True, 
+        fig_size = ( 11, 5 ), 
+        cmap = 'bwr', 
+        font_size =7, 
+        ylabel ='Log10Frequency[$H_z$]', 
+        xlabel='Distance (m)', 
+        cb_label ='Skew: Swift', 
+        )
 #%%
 # The figure above shows the 2D skewness when some outliers are suppressed. 
 # Here most of sites shown a skew less than 0.4  althrough the outliers are suppressed.

--- a/watex/edi.py
+++ b/watex/edi.py
@@ -861,7 +861,6 @@ class Edi :
             >>> ...                   )
 
         """
-        
         # if the interpolation module has not been loaded return
         if interp_import is False:
             raise ImportError('could not interpolate, need to install scipy')
@@ -870,7 +869,7 @@ class Edi :
         if not isinstance(new_freq_array, np.ndarray):
             new_freq_array = np.array(new_freq_array)
             
-        new_freq_array = np.around (new_freq_array, 2)  
+        new_freq_array = np.around (new_freq_array, 5)
         
         if period_buffer is not None:
             if 0. < period_buffer < 1.:


### PR DESCRIPTION
v0.3.1 (March 7, 2024)
-----------------------

Changes and enhancements have been made to the API since version ``v0.3.0``, leading to the introduction of new features and the resolution of various bugs.

- |API change| From now on, only the selected utilities listed below are available as the public API, which has led to shorter loading times for the package. The available 
  public API functions include: 

    - :func:`watex.utils.bi_selector` available publicly as :func:`watex.bi_selector`
    - :func:`watex.utils.cleaner` available publicly as :func:`watex.cleaner`
    - :func:`watex.utils.erpSelector` available publicly as :func:`watex.erpSelector`
    - :func:`watex.utils.erpSmartDetector` available publicly as :func:`watex.erpSmartDetector`
    - :func:`watex.utils.fetch_data` available publicly as :func:`watex.fetch_data`
    - :func:`watex.utils.fittensor` available publicly as :func:`watex.fittensor`
    - :func:`watex.utils.get2dtensor` available publicly as :func:`watex.get2dtensor`
    - :func:`watex.utils.make_erp` available publicly as :func:`watex.make_erp`
    - :func:`watex.utils.make_naive_pipe` available publicly as :func:`watex.make_naive_pipe`
    - :func:`watex.utils.make_ves` available publicly as :func:`watex.make_ves`
    - :func:`watex.utils.magnitude` available publicly as :func:`watex.magnitude`
    - :func:`watex.utils.naive_imputer` available publicly as :func:`watex.naive_imputer`
    - :func:`watex.utils.naive_scaler` available publicly as :func:`watex.naive_scaler`
    - :func:`watex.utils.ohmicArea` available publicly as :func:`watex.ohmicArea`
    - :func:`watex.utils.plotAnomaly` available publicly as :func:`watex.plotAnomaly`
    - :func:`watex.utils.plot_confidence_in` available publicly as :func:`watex.plot_confidence_in`
    - :func:`watex.utils.plotOhmicArea` available publicly as :func:`watex.plotOhmicArea`
    - :func:`watex.utils.plot_sfi` available publicly as :func:`watex.plot_sfi`
    - :func:`watex.utils.power` available publicly as :func:`watex.power`
    - :func:`watex.utils.qc` available publicly as :func:`watex.qc`
    - :func:`watex.utils.read_data` available publicly as :func:`watex.read_data`
    - :func:`watex.utils.selectfeatures` available publicly as :func:`watex.selectfeatures`
    - :func:`watex.utils.sfi` available publicly as :func:`watex.sfi`
    - :func:`watex.utils.shape` available publicly as :func:`watex.shape`
    - :func:`watex.utils.smart_label_classifier` available publicly as :func:`watex.smart_label_classifier`
    - :func:`watex.utils.to_numeric_dtypes` available publicly as :func:`watex.to_numeric_dtypes`
    - :func:`watex.utils.type_` available publicly as :func:`watex.type_`
    - :func:`watex.utils.vesSelector` available publicly as :func:`watex.vesSelector`

- |API change| The parameter ``edi_obj`` in :func:`watex.utils.plot_skew` has been deprecated and replaced by ``edis_list``, which refers to either a collection of :term:`EDI` files or a full path to EDI files. Two-dimensional skewness, represented as :math:`eta`, can now be visualized by setting the parameter ``view='2D'``.

- |API change| The ``xgboost`` library is no longer automatically installed as a dependency. Users must install it separately for complete model functionality or use the ``dev`` option as shown below:

  .. code-block:: bash 

    pip install watex[dev]

- |Fix| The :class:`watex.em.EM` module now throws a :class:`watex.exceptions.EDIError` instead of an ``AttributeError`` when an EDI file is expected but an object is passed.

- |Fix| The `base_estimator` parameter is no longer available in scikit-learn versions greater than 1.2; it has been renamed to `estimator`. Consequently, :mod:`watex.models` and :mod:`watex.models.premodels` have been updated to reflect this change.

- |Feature| The :func:`watex.utils.plotutils.plot_l_curve` function has been introduced to plot the Hansen L-curve, with an option to highlight the Hansen point. This feature uses the L-curve criterion to determine the most suitable model after performing multiple inversions with different :math:`\tau` values.







